### PR TITLE
fix: remove latest from txReceipt call

### DIFF
--- a/src/shared/processor-templates/otoken/otoken.ts
+++ b/src/shared/processor-templates/otoken/otoken.ts
@@ -340,7 +340,7 @@ export const createOTokenProcessor = (params: {
         // OToken transactions.
         const txReceipt = await ctx._chain.client.call(
           'eth_getTransactionReceipt',
-          [log.transactionHash, 'latest'],
+          [log.transactionHash],
         )
 
         const activity = await activityFromTx(


### PR DESCRIPTION
We will probably need to fix other versions too, but I just wanted to create a quick fix